### PR TITLE
fix the wrong called method for houlry forecast, remove unneccessary …

### DIFF
--- a/WeatherAppBackend/Program.cs
+++ b/WeatherAppBackend/Program.cs
@@ -41,23 +41,6 @@ builder.Services.AddSwaggerGen(options =>
         BearerFormat = "JWT",
         Scheme = "Bearer"
     });
-    //options.AddSecurityRequirement(new OpenApiSecurityRequirement
-    //{
-    //    {
-    //        new OpenApiSecurityScheme
-    //        {
-    //            Reference = new OpenApiReference
-    //            {
-    //                Type = ReferenceType.SecurityScheme,
-    //                Id = "Bearer"
-    //            },
-    //            Scheme = "oauth2",
-    //            Name = "Bearer",
-    //            In = ParameterLocation.Header
-    //        },
-    //        new List<string>()
-    //    }
-    //});
     options.OperationFilter<SecurityRequirementsOperationFilter>();
 });
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -95,11 +78,8 @@ using (var scope = app.Services.CreateScope())
     dataContext.Database.Migrate();
 }
 
-//if (app.Environment.IsDevelopment())
-//{
 app.UseSwagger();
 app.UseSwaggerUI();
-//}
 
 app.UseCors(corsPolicyName);
 

--- a/WeatherAppBackend/Service/Impl/WeatherService.cs
+++ b/WeatherAppBackend/Service/Impl/WeatherService.cs
@@ -29,7 +29,7 @@ namespace WeatherAppBackend.Service.Impl
             {
                 var str when str.Equals(ForecastCategoryType.TwoDay.GetType(), StringComparison.OrdinalIgnoreCase) => ConstructUrlForMultipleDayForecast(city, ForecastCategoryType.TwoDay.GetInterval()),
                 var str when str.Equals(ForecastCategoryType.SevenDay.GetType(), StringComparison.OrdinalIgnoreCase) => ConstructUrlForMultipleDayForecast(city, ForecastCategoryType.SevenDay.GetInterval()),
-                var str when str.Equals(ForecastCategoryType.OneHour.GetType(), StringComparison.OrdinalIgnoreCase) => ConstructUrlForMultipleDayForecast(city, ForecastCategoryType.SevenDay.GetInterval()),
+                var str when str.Equals(ForecastCategoryType.OneHour.GetType(), StringComparison.OrdinalIgnoreCase) => ConstructUrlForOneHourForecast(city),
                 _ => GetCurrentWeatherUrl(city),
             };
             return finalConstructedUrl;


### PR DESCRIPTION
By mistake, I had been calling the wrong method for fetching the API data for an hourly forecast on the backend ( based on the filter choice from the frontend which was sent)